### PR TITLE
Feat: Workspace block w/ custom height and dashboard

### DIFF
--- a/metabase_integration/hooks.py
+++ b/metabase_integration/hooks.py
@@ -15,7 +15,7 @@ app_license = "MIT"
 # ------------------
 
 # include js, css files in header of desk.html
-# app_include_css = "/assets/metabase_integration/css/metabase_integration.css"
+app_include_css = "metabase.bundle.css"
 app_include_js = "metabase.bundle.js"
 
 # include js, css files in header of web template

--- a/metabase_integration/public/css/metabase.bundle.css
+++ b/metabase_integration/public/css/metabase.bundle.css
@@ -1,0 +1,18 @@
+.metabase-block__iframe {
+	--h: 25; /* Percentage */
+	--metabase-block-iframe-height: calc((var(--h, 100) / 100) * 800px);
+
+	height: var(--metabase-block-iframe-height, 200px);
+
+	border-radius: 5px;
+	box-shadow: 0 0 0 2px var(--bg-darkgray);
+}
+
+.metabase-block__label {
+	font-weight: bold
+}
+
+.metabase-block__header {
+	padding-bottom: 0.5rem;
+}
+

--- a/metabase_integration/public/metabase.bundle.js
+++ b/metabase_integration/public/metabase.bundle.js
@@ -16,7 +16,7 @@ export default class Metabase extends Block {
 	constructor({ data, api, config, readOnly, block }) {
 		super({ data, api, config, readOnly, block });
 		this.col = this.data.col ? this.data.col : "12";
-        readOnly = 0;
+		readOnly = 0;
 		this.allow_customization = !this.readOnly;
 		this.options = {
 			allow_sorting: this.allow_customization,
@@ -28,27 +28,27 @@ export default class Metabase extends Block {
 			min_width: 6,
 			max_widget_count: 2,
 		};
-        this.iFrameUrl = "";
+		this.iFrameUrl = "";
 	}
 
 	render() {
 		this.wrapper = document.createElement("div");
 		this.iFrameUrl = `
-            <script id="resizer" src="http://localhost:3000/app/iframeResizer.js"></script>
-            <iframe
-                src="http://localhost:3000/embed/dashboard/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjF9LCJwYXJhbXMiOnt9LCJleHAiOjE2Njg3NjkxODF9.N8TXahc_JFp1Et_Z5YWwU0F8u0ovne1uUrmTPTEhYi4#bordered=false&titled=false"
-                frameborder="0"
-                width=100%
-                onload="iFrameResize({}, this)"
-                allowtransparency>
-            </iframe>`
+			<script id="resizer" src="http://localhost:3000/app/iframeResizer.js"></script>
+			<iframe
+				src="http://localhost:3000/embed/dashboard/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjF9LCJwYXJhbXMiOnt9LCJleHAiOjE2Njg3NjkxODF9.N8TXahc_JFp1Et_Z5YWwU0F8u0ovne1uUrmTPTEhYi4#bordered=false&titled=false"
+				frameborder="0"
+				width=100%
+				onload="iFrameResize({}, this)"
+				allowtransparency>
+			</iframe>`
 
-        $(this.iFrameUrl).appendTo(this.wrapper);
+		$(this.iFrameUrl).appendTo(this.wrapper);
 		return this.wrapper;
 	}
 
 	validate(savedData) {
-        console.log(savedData)
+		console.log(savedData)
 		if (!savedData.chart_name) {
 			return false;
 		}
@@ -57,13 +57,13 @@ export default class Metabase extends Block {
 	}
 
 	save() {
-        console.log("SAVE")
+		console.log("SAVE")
 		// return {
 		// 	chart_name: this.wrapper.getAttribute("chart_name"),
 		// 	col: this.get_col(),
 		// 	new: this.new_block_widget,
 		// };
-        return {}
+		return {}
 	}
 }
 

--- a/metabase_integration/public/metabase.bundle.js
+++ b/metabase_integration/public/metabase.bundle.js
@@ -1,5 +1,30 @@
 import EditorJS from "@editorjs/editorjs";
 import Block from "frappe/public/js/frappe/views/workspace/blocks/block.js";
+import get_dialog_constructor from "frappe/public/js/frappe/widgets/widget_dialog.js"
+
+class MetabaseEditDialog extends get_dialog_constructor() {
+	get_fields() {
+		return [
+			{
+				fieldname: "dashboard",
+				fieldtype: "Link",
+				options: "Metabase Dashboard",
+				label: __("Metabase Dashboard"),
+				default: "",
+			},
+			{
+				fieldname: "height",
+				fieldtype: "Int",
+				label: __("Widget Height"),
+				default: 25,
+			},
+		]
+	}
+
+	get_title() {
+		return __("Title") // TODO
+	}
+}
 
 export default class Metabase extends Block {
 	static get toolbox() {
@@ -28,41 +53,172 @@ export default class Metabase extends Block {
 			min_width: 6,
 			max_widget_count: 2,
 		};
-		this.iFrameUrl = "";
 	}
 
 	render() {
+		// if (this.wrapper) { this.wrapper.remove() }
 		this.wrapper = document.createElement("div");
-		this.iFrameUrl = `
-			<script id="resizer" src="http://localhost:3000/app/iframeResizer.js"></script>
-			<iframe
-				src="http://localhost:3000/embed/dashboard/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjF9LCJwYXJhbXMiOnt9LCJleHAiOjE2Njg3NjkxODF9.N8TXahc_JFp1Et_Z5YWwU0F8u0ovne1uUrmTPTEhYi4#bordered=false&titled=false"
-				frameborder="0"
-				width=100%
-				onload="iFrameResize({}, this)"
-				allowtransparency>
-			</iframe>`
+		this.wrapper.classList.add("metabase-block", "widget");
 
-		$(this.iFrameUrl).appendTo(this.wrapper);
+		const $header = $(`<div class="metabase-block__header widget-head"></div>`).appendTo(this.wrapper);
+		const $label = $(`<div class="metabase-block__label">Metabase Dashboard</div>`).appendTo($header);
+
+		// Set-up controls
+		if (!this.readOnly) {
+			const $control = $(`<div class="widget-control metabase-block__control"></div>`).appendTo($header);
+
+			this.wrapper.classList.add("edit-mode");
+
+			this.add_new_block_button();
+			this.add_settings_button();
+
+			frappe.utils.add_custom_button(
+				frappe.utils.icon("drag", "xs"),
+				null,
+				"drag-handle",
+				__("Drag"),
+				null,
+				$control
+			);
+			frappe.utils.add_custom_button(
+				frappe.utils.icon("edit", "xs"),
+				() => this.edit(),
+				"edit-button",
+				__("Edit"),
+				null,
+				$control
+			);
+		}
+
+
+		// Set-up contents
+		this.get_iframe_params().then((params) => {
+			this.rerender_iframe_with_params(params);
+		})
+
 		return this.wrapper;
 	}
 
-	validate(savedData) {
-		console.log(savedData)
-		if (!savedData.chart_name) {
-			return false;
+	edit() {
+		const me = this
+		const dialog = new MetabaseEditDialog({
+			title: __("Edit", [], "Metabase"),
+			type: "metabase-widget", // scrub -> unscrub for title
+			label: "test",
+			values: { // omit values to create new
+				height: this.data.height || 25,
+				dashboard: this.data.dashboard_name || "",
+			},
+			primary_action: (values) => {
+				me.set_widget_height(values.height)
+				me.set_dashboard_name(values.dashboard)
+			},
+		})
+		dialog.make()
+	}
+
+	async get_iframe_params() {
+		/* return {
+			iframeUrl: "http://localhost:3000/embed/dashboard/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjF9LCJwYXJhbXMiOnt9LCJleHAiOjE2Njg3NjkxODF9.N8TXahc_JFp1Et_Z5YWwU0F8u0ovne1uUrmTPTEhYi4#bordered=false&titled=false",
+			resize: "http://localhost:3000/resizer.js",
+		} */
+
+		const dashboard = this.data.dashboard_name;
+
+		if (!dashboard) {
+			return null // TODO
 		}
 
+		return frappe.xcall("metabase_integration.metabase_integration.doctype.metabase_dashboard.get_url", { dashboard })
+	}
+
+	get_widget_height() {
+		const height = (+this.data.height) || 25; // 0, NaN -> 25
+		return Math.max(0, Math.min(100, height)); // clamp to 0-100
+	}
+
+	set_dashboard_name(newName) {
+		this.data.dashboard_name = newName;
+		this.get_iframe_params().then((params) => {
+			this.rerender_iframe_with_params(params);
+		});
+	}
+
+	rerender_iframe_with_params(params) {
+		if (!params) {
+			this.$resizerScript?.remove();
+			this.$resizerScript = null;
+			this.$iframe?.remove();
+			this.$iframe = null;
+			return;
+		}
+
+		const useResize = false;
+		const url = params.iframeUrl;
+		const resizerUrl = params.resizer;
+
+		this.$resizerScript?.remove();
+		if (resizerUrl && useResize) {
+			// Add external script. TODO: Only load once.
+			this.$resizerScript = $(`<script src="${resizerUrl}"></script>`)
+				.appendTo(this.wrapper);
+		}
+
+		if (!url) {
+			// TODO: show error, or even better: show inline dashboard picker
+			this.$iframe?.remove();
+		} else if (!this.$iframe) {
+			// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+			const style = useResize ? "" : `--h: ${this.get_widget_height()};`
+			const scrolling = useResize ? "no" : "yes"
+			this.$iframe = $(`<iframe
+				class="metabase-block__iframe"
+				style="${style}"
+				src="${url}"
+				frameborder="0"
+				scrolling="${scrolling}"
+				width="100%"
+				sandbox="allow-downloads allow-scripts allow-same-origin"
+			></iframe>`).appendTo(this.wrapper);
+
+			if (resizerUrl && useResize) {
+				this.$iframe.addEventListener("onload", function() {
+					iFrameResize({}, this)
+				})
+			}
+		} else {
+			this.$iframe.attr("src", url)
+		}
+	}
+
+	set_widget_height(newHeight) {
+		if (isNaN(newHeight)) {
+			throw new TypeError("Invalid parameter newHeight for set_widget_height: invalid value " + JSON.stringify(newHeight) + ", expected number.");
+		}
+
+		newHeight = +newHeight
+		if (0 > newHeight || newHeight > 100) {
+			throw new TypeError("Invalid parameter newHeight for set_widget_height: value " + newHeight + " must be between 0 and 100.");
+		}
+
+		if (this.$iframe) {
+			this.$iframe.get(0).style.setProperty("--h", newHeight);
+		}
+		this.data.height = newHeight;
+	}
+
+	validate(savedData) {
+		console.log("validate", savedData)
 		return true;
 	}
 
 	save() {
-		console.log("SAVE")
-		// return {
-		// 	chart_name: this.wrapper.getAttribute("chart_name"),
-		// 	col: this.get_col(),
-		// 	new: this.new_block_widget,
-		// };
+		return {
+			dashboard_name: this.data.dashboard_name || "",
+			col: this.get_col() || 12,
+			new: this.new_block_widget || "new",
+			height: this.get_widget_height(),
+		};
 		return {}
 	}
 }


### PR DESCRIPTION
Forward compatibility with a better method patching, but it's still monkey patching, so it's not extra-pretty but it might be more compatible with futures changes in frappe/dodock.

Added buttons to update the block's parameters (height percentage, dashboard name)
<img width="722" alt="image" src="https://user-images.githubusercontent.com/10946971/203638354-e7ee65a7-449e-4b39-a8db-fecb92c483cb.png">
